### PR TITLE
Fix typespec typo in Combine.Parsers.Base

### DIFF
--- a/lib/combine/parsers/base.ex
+++ b/lib/combine/parsers/base.ex
@@ -23,7 +23,7 @@ defmodule Combine.Parsers.Base do
   This parser will fail with the given error message.
   """
   @spec fail(String.t) :: parser
-  @spec fail(parser, String.T) :: parser
+  @spec fail(parser, String.t) :: parser
   defparser fail(%ParserState{status: :ok} = state, message), do: %{state | :status => :error, :error => message}
 
   @doc """


### PR DESCRIPTION
Just found this randomly while testing a new feature for the Elixir compiler.

https://github.com/elixir-lang/elixir/pull/4639#issuecomment-219922496
