### PR TITLE
Lexer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ erl_crash.dump
 *.ez
 doc
 bench/snapshots
+
+sql_lexer.beam
+test/sql_lexer.erl

--- a/lib/combine/parsers/tokenized.ex
+++ b/lib/combine/parsers/tokenized.ex
@@ -1,0 +1,38 @@
+defmodule Combine.Parsers.Tokenized do
+  @moduledoc """
+  This module defines parsers for tokenized inputs. The tokens are assumed
+  to be either `{category, location}` or `{category, location, value}` -
+  just like ones produced by leex. In the former case the value will be equal
+  to the category.
+
+  To use them, just add `import Combine.Parsers.Tokenized` to your module, or
+  reference them directly.
+  """
+
+  alias Combine.ParserState
+  use Combine.Helpers
+
+  @type parser :: Combine.Parsers.Base.parser
+
+  @doc """
+  # Examples
+
+      iex> import #{__MODULE__}
+      ...> parser = token(:hello)
+      ...> Combine.parse([{:hello, 1}], parser)
+      [:hello]
+      ...> Combine.parse([{:hello, 1, :world}], parser)
+      [:world]
+  """
+  @spec token(atom) :: parser
+  @spec token(parser, atom) :: parser
+  defparser token(%ParserState{status: :ok, input: [first | tail], results: results} = state, category) do
+    case first do
+      {^category, pos} -> %{state | column: pos, input: tail, results: [category | results]}
+      {^category, pos, value} -> %{state | column: pos, input: tail, results: [value | results]}
+      {unexpected, pos} -> %{state | status: :error, error: "Unexpected token #{unexpected} at #{pos}"}
+      {unexpected, pos, value} -> %{state | status: :error, error: "Unexpected #{unexpected} #{value} at #{pos}"}
+      other -> "Input contained non-token #{other}"
+    end
+  end
+end

--- a/lib/combine/parsers/tokenized.ex
+++ b/lib/combine/parsers/tokenized.ex
@@ -37,8 +37,8 @@ defmodule Combine.Parsers.Tokenized do
       case hd(input) do
         {^category, pos} -> %{state | column: pos, input: tl(input), results: [category | results]}
         {^category, pos, value} -> %{state | column: pos, input: tl(input), results: [value | results]}
-        {unexpected, pos} -> %{state | status: :error, error: "Unexpected token '#{unexpected}' at #{pos}"}
-        {unexpected, pos, value} -> %{state | status: :error, error: "Unexpected #{unexpected} '#{value}' at #{pos}"}
+        {unexpected, pos} -> %{state | status: :error, error: "Unexpected token '#{unexpected}' at #{inspect(pos)}"}
+        {unexpected, pos, value} -> %{state | status: :error, error: "Unexpected #{unexpected} '#{value}' at #{inspect(pos)}"}
         other -> "Input contained non-token #{other}"
       end
     end

--- a/lib/combine/parsers/tokenized.ex
+++ b/lib/combine/parsers/tokenized.ex
@@ -39,7 +39,7 @@ defmodule Combine.Parsers.Tokenized do
         {^category, pos, value} -> %{state | column: pos, input: tl(input), results: [value | results]}
         {unexpected, pos} -> %{state | status: :error, error: "Unexpected token '#{unexpected}' at #{inspect(pos)}"}
         {unexpected, pos, value} -> %{state | status: :error, error: "Unexpected #{unexpected} '#{value}' at #{inspect(pos)}"}
-        other -> "Input contained non-token #{other}"
+        other -> raise "Input contained non-token #{other}"
       end
     end
   end

--- a/lib/combine/parsers/tokenized.ex
+++ b/lib/combine/parsers/tokenized.ex
@@ -15,6 +15,8 @@ defmodule Combine.Parsers.Tokenized do
   @type parser :: Combine.Parsers.Base.parser
 
   @doc """
+  Parser a single token of the form `{category, location}` or `{category, location, value}`
+
   # Examples
 
   iex> import #{__MODULE__}
@@ -35,8 +37,8 @@ defmodule Combine.Parsers.Tokenized do
       case hd(input) do
         {^category, pos} -> %{state | column: pos, input: tl(input), results: [category | results]}
         {^category, pos, value} -> %{state | column: pos, input: tl(input), results: [value | results]}
-        {unexpected, pos} -> %{state | status: :error, error: "Unexpected token #{unexpected} at #{pos}"}
-        {unexpected, pos, value} -> %{state | status: :error, error: "Unexpected #{unexpected} #{value} at #{pos}"}
+        {unexpected, pos} -> %{state | status: :error, error: "Unexpected token '#{unexpected}' at #{pos}"}
+        {unexpected, pos, value} -> %{state | status: :error, error: "Unexpected #{unexpected} '#{value}' at #{pos}"}
         other -> "Input contained non-token #{other}"
       end
     end

--- a/test/parsers/tokenized_test.exs
+++ b/test/parsers/tokenized_test.exs
@@ -4,4 +4,21 @@ defmodule Combine.Parsers.Tokenized.Test do
   doctest Combine.Parsers.Tokenized
 
   import Combine.Parsers.Tokenized
+
+  test "integration with a leex lexer" do
+    use Combine
+    import ExUnit.CaptureIO
+
+    {:ok, file} = :leex.file('test/sql_lexer.xrl')
+    capture_io(fn -> :compile.file(file) end)
+    Code.ensure_loaded(:sql_lexer)
+
+    parser = token(:select)
+    |> (sep_by1(token(:identifier), token(:comma)) |> map(&{:columns, &1}))
+    |> token(:from)
+    |> (token(:identifier) |> map(&{:table_name, &1}))
+
+    {:ok, tokens, _} = :sql_lexer.string('SELECT a, b FROM c')
+    assert Combine.parse(tokens, parser) == [:select, {:columns, ['a', 'b']}, :from, {:table_name, 'c'}]
+  end
 end

--- a/test/parsers/tokenized_test.exs
+++ b/test/parsers/tokenized_test.exs
@@ -1,0 +1,7 @@
+defmodule Combine.Parsers.Tokenized.Test do
+  use ExUnit.Case, async: true
+
+  doctest Combine.Parsers.Tokenized
+
+  import Combine.Parsers.Tokenized
+end

--- a/test/sql_lexer.xrl
+++ b/test/sql_lexer.xrl
@@ -1,0 +1,14 @@
+Definitions.
+
+IDENTIFIER = [a-z_]+
+WHITESPACE = [\s\t\n\r]
+
+Rules.
+
+{IDENTIFIER}  : {token, {identifier, TokenLine, TokenChars}}.
+SELECT        : {token, {select, TokenLine}}.
+FROM          : {token, {from, TokenLine}}.
+,             : {token, {comma, TokenLine}}.
+{WHITESPACE}+ : skip_token.
+
+Erlang code.


### PR DESCRIPTION
I took a stab at implementing #10 (or at least supporting leex tokens). Given the file "lexer.xrl":

``` erlang
Definitions.

IDENTIFIER = [a-z_]+
WHITESPACE = [\s\t\n\r]

Rules.

{IDENTIFIER}  : {token, {identifier, TokenLine, TokenChars}}.
SELECT        : {token, {select, TokenLine}}.
FROM          : {token, {from, TokenLine}}.
{WHITESPACE}+ : skip_token.

Erlang code.
```

You can do the following:

``` elixir
{:ok, file} = :leex.file('lexer.xrl')
c("lexer.erl")
{:ok, tokens, _} = :lexer.string('SELECT a FROM b')
tokens #> [{:select, 1}, {:identifier, 1, 'a'}, {:from, 1}, {:identifier, 1, 'b'}]

use Combine
import Combine.Parsers.Tokenized

parser = token(:select) |> token(:identifier) |> token(:from) |> token(:identifier)
Combine.parse(tokens, parser) #> [:select, 'a', :from, 'b']
```

One bad thing about leex specifically is that it only exposes `TokenLine`, there doesn't seem to be a way to get the column where the token occurs. I guess one might write a lexer manually that would be better at that (for example using combine :))
