### PR TITLE
Unify parsers

### DIFF
--- a/lib/combine.ex
+++ b/lib/combine.ex
@@ -40,7 +40,8 @@ defmodule Combine do
     end
   end
 
-  @type parser :: Combine.Parsers.Base.parser
+  @type parser           :: (ParserState.t() -> ParserState.t)
+  @type previous_parser  :: parser | nil
 
   @doc """
   Given an input string and a parser, applies the parser to the input string,

--- a/lib/combine/helpers.ex
+++ b/lib/combine/helpers.ex
@@ -30,15 +30,18 @@ defmodule Combine.Helpers do
     end
 
     quote do
-      def unquote(name)(unquote_splicing(other_args)) do
-        fn state -> unquote(impl_name)(state, unquote_splicing(other_args)) end
-      end
-      def unquote(name)(parser, unquote_splicing(other_args)) when is_function(parser, 1) do
-        fn
-          %Combine.ParserState{status: :ok} = state ->
-            unquote(impl_name)(parser.(state), unquote_splicing(other_args))
-          %Combine.ParserState{} = state ->
-            state
+      def unquote(name)(parser \\ nil, unquote_splicing(other_args))
+        when parser == nil or is_function(parser, 1)
+      do
+        if parser == nil do
+          fn state -> unquote(impl_name)(state, unquote_splicing(other_args)) end
+        else
+          fn
+            %Combine.ParserState{status: :ok} = state ->
+              unquote(impl_name)(parser.(state), unquote_splicing(other_args))
+            %Combine.ParserState{} = state ->
+              state
+          end
         end
       end
       defp unquote(impl_name)(%Combine.ParserState{status: :error} = state, unquote_splicing(other_args)), do: state

--- a/lib/combine/helpers.ex
+++ b/lib/combine/helpers.ex
@@ -5,6 +5,9 @@ defmodule Combine.Helpers do
     quote do
       require Combine.Helpers
       import Combine.Helpers
+
+      @type parser           :: Combine.parser
+      @type previous_parser  :: Combine.previous_parser
     end
   end
 

--- a/lib/combine/parsers/base.ex
+++ b/lib/combine/parsers/base.ex
@@ -544,7 +544,6 @@ defmodule Combine.Parsers.Base do
   """
   @spec one_of(parser, Range.t | list()) :: parser
   @spec one_of(parser, parser, Range.t | list()) :: parser
-  def one_of(parser, %Range{} = items), do: one_of(parser, items)
   defparser one_of(%ParserState{status: :ok, line: line, column: col} = state, parser, items)
     when is_function(parser, 1) do
       case parser.(state) do
@@ -559,7 +558,6 @@ defmodule Combine.Parsers.Base do
         %ParserState{} = s -> s
       end
   end
-  def one_of(parser1, parser2, %Range{} = items), do: one_of(parser1, parser2, items)
 
   @doc """
   Applies a parser and then verifies that the result is not contained in the provided list of matches.

--- a/lib/combine/parsers/base.ex
+++ b/lib/combine/parsers/base.ex
@@ -7,7 +7,6 @@ defmodule Combine.Parsers.Base do
   alias Combine.ParserState
   use Combine.Helpers
 
-  @type parser     :: (Combine.ParserState.t() -> Combine.ParserState.t)
   @type predicate  :: (term -> boolean)
   @type transform  :: (term -> term)
   @type transform2 :: ((term, term) -> term)
@@ -15,22 +14,19 @@ defmodule Combine.Parsers.Base do
   @doc """
   This parser will fail with no error.
   """
-  @spec zero() :: parser
-  @spec zero(parser) :: parser
+  @spec zero(previous_parser) :: parser
   defparser zero(%ParserState{status: :ok} = state), do: %{state | :status => :error, :error => nil}
 
   @doc """
   This parser will fail with the given error message.
   """
-  @spec fail(String.t) :: parser
-  @spec fail(parser, String.t) :: parser
+  @spec fail(previous_parser, String.t) :: parser
   defparser fail(%ParserState{status: :ok} = state, message), do: %{state | :status => :error, :error => message}
 
   @doc """
   This parser will fail fatally with the given error message.
   """
-  @spec fatal(String.t) :: parser
-  @spec fatal(parser, String.t) :: parser
+  @spec fatal(previous_parser, String.t) :: parser
   defparser fatal(%ParserState{status: :ok} = state, message), do: %{state | :status => :error, :error => {:fatal, message}}
 
   @doc """
@@ -44,8 +40,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("  ", spaces |> eof)
       [" "]
   """
-  @spec eof() :: parser
-  @spec eof(parser) :: parser
+  @spec eof(previous_parser) :: parser
   defparser eof(%ParserState{status: :ok, input: <<>>} = state), do: state
   defp eof_impl(%ParserState{status: :ok, line: line, column: col} = state) do
     %{state | :status => :error, :error => "Expected end of input at line #{line}, column #{col}"}
@@ -63,8 +58,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("1234", map(integer, &(&1 * 2)))
       [2468]
   """
-  @spec map(parser, transform) :: parser
-  @spec map(parser, parser, transform) :: parser
+  @spec map(previous_parser, parser, transform) :: parser
   defparser map(%ParserState{status: :ok} = state, parser, transform) do
     case parser.(state) do
       %ParserState{status: :ok, results: [h|rest]} = s ->
@@ -87,8 +81,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("Hi", option(integer) |> word)
       [nil, "Hi"]
   """
-  @spec option(parser) :: parser
-  @spec option(parser, parser) :: parser
+  @spec option(previous_parser, parser) :: parser
   defparser option(%ParserState{status: :ok, results: results} = state, parser) when is_function(parser, 1) do
     case parser.(state) do
       %ParserState{status: :ok} = s -> s
@@ -107,8 +100,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("1234", either(float, integer))
       [1234]
   """
-  @spec either(parser, parser) :: parser
-  @spec either(parser, parser, parser) :: parser
+  @spec either(previous_parser, parser, parser) :: parser
   defparser either(%ParserState{status: :ok} = state, parser1, parser2) do
     case parser1.(state) do
       %ParserState{status: :ok} = s1 -> s1
@@ -131,8 +123,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("test", choice([float, integer, word]))
       ["test"]
   """
-  @spec choice([parser]) :: parser
-  @spec choice(parser, [parser]) :: parser
+  @spec choice(previous_parser, [parser]) :: parser
   defparser choice(%ParserState{status: :ok} = state, parsers) do
     try_choice(parsers, state, nil)
   end
@@ -155,8 +146,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("123", pipe([digit, digit, digit], fn digits -> {n, _} = Integer.parse(Enum.join(digits)); n end))
       [123]
   """
-  @spec pipe([parser], transform) :: parser
-  @spec pipe(parser, [parser], transform) :: parser
+  @spec pipe(previous_parser, [parser], transform) :: parser
   defparser pipe(%ParserState{status: :ok} = state, parsers, transform) when is_list(parsers) and is_function(transform, 1) do
     orig_results = state.results
     case do_pipe(parsers, %{state | :results => []}) do
@@ -191,8 +181,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("123-234", sequence([integer, char]) |> map(sequence([integer]), fn [x] -> x * 2 end))
       [[123, "-"], 468]
   """
-  @spec sequence([parser]) :: parser
-  @spec sequence(parser, [parser]) :: parser
+  @spec sequence(previous_parser, [parser]) :: parser
   defparser sequence(%ParserState{status: :ok} = state, parsers) when is_list(parsers) do
     pipe(parsers, &(&1)).(state)
   end
@@ -210,8 +199,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("1234-234", both(integer, both(char, integer, to_int), &(&1 + &2)))
       [1000]
   """
-  @spec both(parser, parser, transform2) :: parser
-  @spec both(parser, parser, parser, transform2) :: parser
+  @spec both(previous_parser, parser, parser, transform2) :: parser
   defparser both(%ParserState{status: :ok} = state, parser1, parser2, transform) do
     pipe([parser1, parser2], fn results -> apply(transform, results) end).(state)
   end
@@ -226,8 +214,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("234-", pair_left(integer, char))
       [234]
   """
-  @spec pair_left(parser, parser) :: parser
-  @spec pair_left(parser, parser, parser) :: parser
+  @spec pair_left(previous_parser, parser, parser) :: parser
   defparser pair_left(%ParserState{status: :ok} = state, parser1, parser2) do
     pipe([parser1, parser2], fn [result1, _] -> result1 end).(state)
   end
@@ -242,8 +229,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("-234", pair_right(char, integer))
       [234]
   """
-  @spec pair_right(parser, parser) :: parser
-  @spec pair_right(parser, parser, parser) :: parser
+  @spec pair_right(previous_parser, parser, parser) :: parser
   defparser pair_right(%ParserState{status: :ok} = state, parser1, parser2) do
     pipe([parser1, parser2], fn [_, result2] -> result2 end).(state)
   end
@@ -258,8 +244,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("-234", pair_both(char, integer))
       [{"-", 234}]
   """
-  @spec pair_both(parser, parser) :: parser
-  @spec pair_both(parser, parser, parser) :: parser
+  @spec pair_both(previous_parser, parser, parser) :: parser
   defparser pair_both(%ParserState{status: :ok} = state, parser1, parser2) do
     pipe([parser1, parser2], fn [result1, result2] -> {result1, result2} end).(state)
   end
@@ -275,8 +260,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("(234)", between(char("("), integer, char(")")))
       [234]
   """
-  @spec between(parser, parser, parser) :: parser
-  @spec between(parser, parser, parser, parser) :: parser
+  @spec between(previous_parser, parser, parser, parser) :: parser
   defparser between(%ParserState{status: :ok} = state, parser1, parser2, parser3) do
     pipe([parser1, parser2, parser3], fn [_, result, _] -> result end).(state)
   end
@@ -291,8 +275,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("123", times(digit, 3))
       [[1,2,3]]
   """
-  @spec times(parser, pos_integer) :: parser
-  @spec times(parser, parser, pos_integer) :: parser
+  @spec times(previous_parser, parser, pos_integer) :: parser
   defparser times(%ParserState{status: :ok} = state, parser, n) when is_function(parser, 1) and is_integer(n) do
     case do_times(n, parser, state) do
       {:ok, acc, %ParserState{status: :ok, results: rs} = new_state} ->
@@ -328,8 +311,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("12abc", digit |> digit |> many1(ignore(char)))
       [1, 2, []]
   """
-  @spec many1(parser) :: parser
-  @spec many1(parser, parser) :: parser
+  @spec many1(previous_parser, parser) :: parser
   defparser many1(%ParserState{status: :ok, results: initial_results} = state, parser) when is_function(parser, 1) do
     case many1_loop(0, [], state, parser.(state), parser) do
       {results, %ParserState{status: :ok} = s} ->
@@ -361,8 +343,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("", many(char))
       [[]]
   """
-  @spec many(parser) :: parser
-  @spec many(parser, parser) :: parser
+  @spec many(previous_parser, parser) :: parser
   defparser many(%ParserState{status: :ok, results: results} = state, parser) when is_function(parser, 1) do
     case many1(parser).(state) do
       %ParserState{status: :ok} = s -> s
@@ -381,8 +362,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("1, 2, 3", sep_by1(digit, string(", ")))
       [[1, 2, 3]]
   """
-  @spec sep_by1(parser, parser) :: parser
-  @spec sep_by1(parser, parser, parser) :: parser
+  @spec sep_by1(previous_parser, parser, parser) :: parser
   defparser sep_by1(%ParserState{status: :ok} = state, parser1, parser2) do
     pipe([parser1, many(pair_right(parser2, parser1))], fn [h, t] -> [h|t] end).(state)
   end
@@ -400,8 +380,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("", sep_by(digit, string(", ")))
       [[]]
   """
-  @spec sep_by(parser, parser) :: parser
-  @spec sep_by(parser, parser, parser) :: parser
+  @spec sep_by(previous_parser, parser, parser) :: parser
   defparser sep_by(%ParserState{status: :ok, results: results} = state, parser1, parser2)
     when is_function(parser1, 1) and is_function(parser2, 1) do
       case sep_by1_impl(state, parser1, parser2) do
@@ -422,8 +401,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("", skip(spaces))
       []
   """
-  @spec skip(parser) :: parser
-  @spec skip(parser, parser) :: parser
+  @spec skip(previous_parser, parser) :: parser
   defparser skip(%ParserState{status: :ok} = state, parser) when is_function(parser, 1) do
     case ignore_impl(state, option(parser)) do
       %ParserState{status: :ok, results: [:__ignore|rs]} = s ->
@@ -445,8 +423,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("", skip_many(space))
       []
   """
-  @spec skip_many(parser) :: parser
-  @spec skip_many(parser, parser) :: parser
+  @spec skip_many(previous_parser, parser) :: parser
   defparser skip_many(%ParserState{status: :ok} = state, parser) when is_function(parser, 1) do
     ignore_impl(state, many(parser))
   end
@@ -463,8 +440,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("", skip_many1(space))
       {:error, "Expected space, but hit end of input."}
   """
-  @spec skip_many1(parser) :: parser
-  @spec skip_many1(parser, parser) :: parser
+  @spec skip_many1(previous_parser, parser) :: parser
   defparser skip_many1(%ParserState{status: :ok} = state, parser) when is_function(parser, 1) do
     ignore_impl(state, many1(parser))
   end
@@ -484,8 +460,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("hi !", parser)
       ["h", "i", "!"]
   """
-  @spec ignore(parser) :: parser
-  @spec ignore(parser, parser) :: parser
+  @spec ignore(previous_parser, parser) :: parser
   defparser ignore(%ParserState{status: :ok} = state, parser) when is_function(parser, 1) do
     case parser.(state) do
       %ParserState{status: :ok, results: [_|t]} = s -> %{s | :results => [:__ignore|t]}
@@ -509,8 +484,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("Hi", parser)
       ["H", "i"]
   """
-  @spec satisfy(parser, predicate) :: parser
-  @spec satisfy(parser, parser, predicate) :: parser
+  @spec satisfy(previous_parser, parser, predicate) :: parser
   defparser satisfy(%ParserState{status: :ok, line: line, column: col} = state, parser, predicate)
     when is_function(parser, 1) and is_function(predicate, 1) do
       case parser.(state) do
@@ -542,8 +516,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("Hi", parser)
       ["H", "i"]
   """
-  @spec one_of(parser, Range.t | list()) :: parser
-  @spec one_of(parser, parser, Range.t | list()) :: parser
+  @spec one_of(previous_parser, parser, Range.t | list()) :: parser
   defparser one_of(%ParserState{status: :ok, line: line, column: col} = state, parser, items)
     when is_function(parser, 1) do
       case parser.(state) do
@@ -573,8 +546,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("Hello", parser)
       ["H", "e"]
   """
-  @spec none_of(parser, Range.t | list()) :: parser
-  @spec none_of(parser, parser, Range.t | list()) :: parser
+  @spec none_of(previous_parser, parser, Range.t | list()) :: parser
   defparser none_of(%ParserState{status: :ok, line: line, column: col} = state, parser, items)
     when is_function(parser, 1) do
       case parser.(state) do
@@ -602,8 +574,7 @@ defmodule Combine.Parsers.Base do
       ...> Combine.parse("abc", label(integer, "year"))
       {:error, "Expected `year` at line 1, column 1."}
   """
-  @spec label(parser, String.t) :: parser
-  @spec label(parser, parser, String.t) :: parser
+  @spec label(previous_parser, parser, String.t) :: parser
   defparser label(%ParserState{status: :ok} = state, parser, name) when is_function(parser, 1) do
     case parser.(state) do
       %ParserState{status: :ok} = s -> s

--- a/lib/combine/parsers/binary.ex
+++ b/lib/combine/parsers/binary.ex
@@ -9,8 +9,6 @@ defmodule Combine.Parsers.Binary do
   alias Combine.ParserState
   use Combine.Helpers
 
-  @type parser :: Combine.Parsers.Base.parser
-
   @doc """
   This parser parses N bits from the input.
 
@@ -22,8 +20,7 @@ defmodule Combine.Parsers.Binary do
       ...> Combine.parse("Hi", bits(8) |> bits(8))
       ["H", "i"]
   """
-  @spec bits(pos_integer) :: parser
-  @spec bits(parser, pos_integer) :: parser
+  @spec bits(previous_parser, pos_integer) :: parser
   defparser bits(%ParserState{status: :ok, column: col, input: input, results: results} = state, n) when is_integer(n) do
     case input do
       <<bits::bitstring-size(n), rest::bitstring>> ->
@@ -44,8 +41,7 @@ defmodule Combine.Parsers.Binary do
       ...> Combine.parse("Hi", bytes(1) |> bytes(1))
       ["H", "i"]
   """
-  @spec bytes(pos_integer) :: parser
-  @spec bytes(parser, pos_integer) :: parser
+  @spec bytes(previous_parser, pos_integer) :: parser
   defparser bytes(%ParserState{status: :ok, column: col, input: input, results: results} = state, n) when is_integer(n) do
     bits_size = n * 8
     case input do
@@ -66,8 +62,7 @@ defmodule Combine.Parsers.Binary do
       ...> Combine.parse(<<85::big-unsigned-size(16), "-90"::binary>>, uint(16, :be))
       [85]
   """
-  @spec uint(pos_integer, :be | :le) :: parser
-  @spec uint(parser, pos_integer, :be | :le) :: parser
+  @spec uint(previous_parser, pos_integer, :be | :le) :: parser
   defparser uint(%ParserState{status: :ok, column: col, input: input, results: results} = state, size, endianness) do
     case endianness do
       :be ->
@@ -97,8 +92,7 @@ defmodule Combine.Parsers.Binary do
       ...> Combine.parse(<<-85::big-signed-size(16),"-90"::binary>>, int(16, :be))
       [-85]
   """
-  @spec int(pos_integer, :be | :le) :: parser
-  @spec int(parser, pos_integer, :be | :le) :: parser
+  @spec int(previous_parser, pos_integer, :be | :le) :: parser
   defparser int(%ParserState{status: :ok, column: col, input: input, results: results} = state, size, endianness)
     when is_integer(size) and endianness in [:be, :le] do
     case endianness do
@@ -128,8 +122,7 @@ defmodule Combine.Parsers.Binary do
       ...> Combine.parse(<<2.50::float-size(32)>>, float(32))
       [2.5]
   """
-  @spec float(32 | 64) :: parser
-  @spec float(parser, 32 | 64) :: parser
+  @spec float(previous_parser, 32 | 64) :: parser
   defparser float(%ParserState{status: :ok, column: col, input: input, results: results} = state, size) when is_integer(size) do
     case input do
       <<num::float-size(size), rest::bitstring>> ->

--- a/lib/combine/parsers/text.ex
+++ b/lib/combine/parsers/text.ex
@@ -8,8 +8,6 @@ defmodule Combine.Parsers.Text do
   alias Combine.Parsers.Base
   use Combine.Helpers
 
-  @type parser :: Combine.Parsers.Base.parser
-
   @lower_alpha   ?a..?z |> Enum.to_list
   @upper_alpha   ?A..?Z |> Enum.to_list
   @alpha         @lower_alpha ++ @upper_alpha
@@ -98,8 +96,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("aaaaabbbbb", parser)
       ['aaaaa']
   """
-  @spec take_while((char -> boolean)) :: parser
-  @spec take_while(parser, (char -> boolean)) :: parser
+  @spec take_while(previous_parser, (char -> boolean)) :: parser
   defparser take_while(%ParserState{status: :ok} = state, predicate) when is_function(predicate, 1) do
     take_while_loop(state, predicate, [])
   end
@@ -123,8 +120,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("hi", char("h") |> letter)
       ["h", "i"]
   """
-  @spec letter() :: parser
-  @spec letter(parser) :: parser
+  @spec letter(previous_parser) :: parser
   defparser letter(%ParserState{status: :ok, column: col, input: <<c::utf8,rest::binary>>, results: results} = state)
     when c in @alpha do
       %{state | :column => col + 1, :input => rest, :results => [<<c::utf8>>|results]}
@@ -147,8 +143,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("HI", char("H") |> upper)
       ["H", "I"]
   """
-  @spec upper() :: parser
-  @spec upper(parser) :: parser
+  @spec upper(previous_parser) :: parser
   defparser upper(%ParserState{status: :ok, line: line, column: col, input: <<cp::utf8, rest::binary>>, results: results} = state) do
     cstr = <<cp::utf8>>
     cond do
@@ -171,8 +166,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("Hi", char("H") |> lower)
       ["H", "i"]
   """
-  @spec lower() :: parser
-  @spec lower(parser) :: parser
+  @spec lower(previous_parser) :: parser
   defparser lower(%ParserState{status: :ok, line: line, column: col, input: <<cp::utf8, rest::binary>>, results: results} = state) do
     cstr = <<cp::utf8>>
     cond do
@@ -196,8 +190,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("hi !", parser)
       ["h", "i", " ", "!"]
   """
-  @spec space() :: parser
-  @spec space(parser) :: parser
+  @spec space(previous_parser) :: parser
   defparser space(%ParserState{status: :ok, column: col, input: <<?\s::utf8,rest::binary>>, results: results} = state) do
     %{state | :column => col + 1, :input => rest, :results => [" "|results]}
   end
@@ -220,10 +213,8 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("Hi   Paul", string("Hi") |> spaces |> string("Paul"))
       ["Hi", " ", "Paul"]
   """
-  @spec spaces() :: parser
-  @spec spaces(parser) :: parser
-  def spaces(),       do: Base.map(Base.many1(space), fn _ -> " " end)
-  def spaces(parser), do: parser |> Base.map(Base.many1(space), fn _ -> " " end)
+  @spec spaces(previous_parser) :: parser
+  def spaces(parser \\ nil), do: parser |> Base.map(Base.many1(space), fn _ -> " " end)
 
   @doc """
   This parser will parse a single tab character from the input.
@@ -237,8 +228,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("hi\t!", parser)
       ["h", "i", "\t", "!"]
   """
-  @spec tab() :: parser
-  @spec tab(parser) :: parser
+  @spec tab(previous_parser) :: parser
   defparser tab(%ParserState{status: :ok, column: col, input: <<?\t::utf8,rest::binary>>, results: results} = state) do
     %{state | :column => col + 1, :input => rest, :results => ["\t"|results]}
   end
@@ -261,8 +251,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("H\\r\\n", upper |> newline)
       ["H", "\\n"]
   """
-  @spec newline() :: parser
-  @spec newline(parser) :: parser
+  @spec newline(previous_parser) :: parser
   defparser newline(%ParserState{status: :ok, column: col, input: <<?\n::utf8,rest::binary>>, results: results} = state) do
     %{state | :column => col + 1, :input => rest, :results => ["\n"|results]}
   end
@@ -294,8 +283,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("1010", digit |> digit)
       [1, 0]
   """
-  @spec digit() :: parser
-  @spec digit(parser) :: parser
+  @spec digit(previous_parser) :: parser
   defparser digit(%ParserState{status: :ok, column: col, input: <<c::utf8,rest::binary>>, results: results} = state)
     when c in @digits do
       digit = case c do
@@ -330,8 +318,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("1010", bin_digit |> bin_digit)
       [1, 0]
   """
-  @spec bin_digit() :: parser
-  @spec bin_digit(parser) :: parser
+  @spec bin_digit(previous_parser) :: parser
   defparser bin_digit(%ParserState{status: :ok, column: col, input: <<c::utf8,rest::binary>>, results: results} = state)
     when c in [?0, ?1] do
       val = case c do
@@ -358,8 +345,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("3157", octal_digit |> octal_digit)
       [3, 1]
   """
-  @spec octal_digit() :: parser
-  @spec octal_digit(parser) :: parser
+  @spec octal_digit(previous_parser) :: parser
   defparser octal_digit(%ParserState{status: :ok, column: col, input: <<c::utf8,rest::binary>>, results: results} = state)
     when c in ?0..?7 do
       val = case c do
@@ -392,8 +378,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("d3adbeeF", hex_digit |> hex_digit)
       ["d", "3"]
   """
-  @spec hex_digit() :: parser
-  @spec hex_digit(parser) :: parser
+  @spec hex_digit(previous_parser) :: parser
   defparser hex_digit(%ParserState{status: :ok, column: col, input: <<c::utf8,rest::binary>>, results: results} = state)
     when c in @hexadecimal do
       %{state | :column => col + 1, :input => rest, :results => [<<c::utf8>>|results]}
@@ -416,8 +401,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("d3", alphanumeric |> alphanumeric)
       ["d", "3"]
   """
-  @spec alphanumeric() :: parser
-  @spec alphanumeric(parser) :: parser
+  @spec alphanumeric(previous_parser) :: parser
   defparser alphanumeric(%ParserState{status: :ok, column: col, input: <<c::utf8,rest::binary>>, results: results} = state)
     when c in @alphanumeric do
       %{state | :column => col + 1, :input => rest, :results => [<<c::utf8>>|results]}
@@ -440,8 +424,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("Hi Paul", string("Hi") |> space |> string("Paul"))
       ["Hi", " ", "Paul"]
   """
-  @spec string(String.t) :: parser
-  @spec string(parser, String.t) :: parser
+  @spec string(previous_parser, String.t) :: parser
   defparser string(%ParserState{status: :ok, line: line, column: col, input: input, results: results} = state, expected)
     when is_binary(expected) do
       byte_size = :erlang.size(expected)
@@ -465,10 +448,8 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("Hi Paul", word |> space |> word)
       ["Hi", " ", "Paul"]
   """
-  @spec word() :: parser
-  @spec word(parser) :: parser
-  def word(),       do: word_of(~r/\w+/)
-  def word(parser), do: word_of(parser, ~r/\w+/)
+  @spec word(previous_parser) :: parser
+  def word(parser \\ nil),       do: word_of(parser, ~r/\w+/)
 
   @doc """
   Parses a string where each character matches the provided regular expression.
@@ -480,8 +461,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("something_with-special:characters!", word_of(valid_chars))
       ["something_with-special:characters!"]
   """
-  @spec word_of(Regex.t) :: parser
-  @spec word_of(parser, Regex.t) :: parser
+  @spec word_of(previous_parser, Regex.t) :: parser
   defparser word_of(%ParserState{status: :ok, line: line, column: col, input: input, results: results} = state, pattern) do
     source = case Regex.source(pattern) do
       <<?^, _::binary>> = source ->
@@ -520,8 +500,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("stuff, 1234", word |> char(",") |> space |> integer)
       ["stuff", ",", " ", 1234]
   """
-  @spec integer() :: parser
-  @spec integer(parser) :: parser
+  @spec integer(previous_parser) :: parser
   defparser integer(%ParserState{status: :ok} = state), do: fixed_integer(-1).(state)
 
   @doc """
@@ -535,8 +514,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse(":1234", char |> fixed_integer(3))
       [":", 123]
   """
-  @spec fixed_integer(-1 | pos_integer) :: parser
-  @spec fixed_integer(parser, -1 | pos_integer) :: parser
+  @spec fixed_integer(previous_parser, -1 | pos_integer) :: parser
   defparser fixed_integer(%ParserState{status: :ok, column: col, input: <<c::utf8,rest::binary>> = input, results: results} = state, size)
     when c in @digits do
       case extract_integer(rest, <<c::utf8>>, size - 1) do
@@ -582,8 +560,7 @@ defmodule Combine.Parsers.Text do
       ...> Combine.parse("float: 1234.5", word |> char(":") |> space |> float)
       ["float", ":", " ", 1234.5]
   """
-  @spec float() :: parser
-  @spec float(parser) :: parser
+  @spec float(previous_parser) :: parser
   defparser float(%ParserState{status: :ok, line: line, column: col, input: <<c::utf8,rest::binary>> = input, results: results} = state)
     when c in @digits do
       case extract_float(rest, <<c::utf8>>, false, <<c::utf8>>) do

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,8 @@ defmodule Combine.Mixfile do
      start_permanent: Mix.env == :prod,
      description: "A parser combinator library for Elixir projects.",
      package: package,
-     deps: deps]
+     deps: deps,
+     docs: [source_url: "https://github.com/bitwalker/combine/"]]
   end
 
   def application, do: [applications: []]


### PR DESCRIPTION
This PR replaces two functions generated by `defparser` with a single fun def using a default arg. This has the following benefits:
- Docs for parsers are now unified
- Default args can be used for other parameters

The second benefit is admittedly shady, since in that case you'd always need to provide the first arg (previous parser) to be able to override other defaults.

However, the first benefit reduces the need to write two specs for each parser. It also allows to use e.g. `@doc false` to suppress doc for some parser. With the master version this is not possible, as `@doc` will affect only the first created function.

In addition, I added an option to include links to GH repo in the generated docs so it's a bit more easier to see the implementation of some parser, if needed.
