### PR TITLE
fix(typespec): fix dialyzer errors, remove dead code

### DIFF
--- a/lib/combine/parser_state.ex
+++ b/lib/combine/parser_state.ex
@@ -11,6 +11,16 @@ defmodule Combine.ParserState do
     - `status` - `:ok` if the grammar rules are satisfied, `:error` otherwise
     - `error` - an error message if a grammar rule wasn't satisfied
   """
+
+  @type t :: %__MODULE__{
+    input: binary,
+    column: pos_integer,
+    line: pos_integer,
+    results: [any],
+    status: :ok | :error,
+    error: any
+  }
+
   defstruct input: <<>>,
             column: 0,
             line: 1,

--- a/lib/combine/parser_state.ex
+++ b/lib/combine/parser_state.ex
@@ -14,7 +14,7 @@ defmodule Combine.ParserState do
 
   @type t :: %__MODULE__{
     input: binary,
-    column: pos_integer,
+    column: non_neg_integer,
     line: pos_integer,
     results: [any],
     status: :ok | :error,

--- a/lib/combine/parsers/base.ex
+++ b/lib/combine/parsers/base.ex
@@ -295,7 +295,6 @@ defmodule Combine.Parsers.Base do
       %ParserState{} = next -> {:error, acc, next}
     end
   end
-  defp do_times(_count, _parser, %ParserState{} = state, acc), do: {:error, acc, state}
 
   @doc """
   Applies `parser` one or more times. Returns results as a list.

--- a/lib/combine/parsers/text.ex
+++ b/lib/combine/parsers/text.ex
@@ -52,7 +52,7 @@ defmodule Combine.Parsers.Text do
       ["H"]
   """
   @spec char(parser | String.t | pos_integer) :: parser
-  @spec char(parser, String.t | pos_integer) :: parser
+  @spec char(previous_parser, String.t | pos_integer) :: parser
   def char(c) when is_integer(c) do
     fn state -> char_impl(state, c) end
   end


### PR DESCRIPTION
This PR fixes a few issues I found running dialyzer in a project I have which uses Combine.

1) `ParserState.t` was undefined
2) The `char` spec was incorrect

Running dialyzer in combine then showed that the last clause for `do_times` was always covered. I think this is because the incoming `ParserState` will always be `:ok` coming into `do_times`. All of the tests passed as well, but feel free to reject that change and I will submit just the corrected typespecs.