### PR TITLE
Remove Elixir 1.4 compile warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule Combine.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: "A parser combinator library for Elixir projects.",
-     package: package,
-     deps: deps,
+     package: package(),
+     deps: deps(),
      docs: [source_url: "https://github.com/bitwalker/combine/"]]
   end
 


### PR DESCRIPTION
Elixir 1.4 issues a warning when a function is called without parenthesis or parameters
![image](https://cloud.githubusercontent.com/assets/1638049/20976630/b5b773ee-bc68-11e6-91b5-784842fcaed4.png)

The warning appears also when combine is a transitive dependency of any project and the user runs ```mix deps.compile```.