### PR TITLE
bugfix: col index should properly update for UTF strings

### DIFF
--- a/lib/combine/parsers/text.ex
+++ b/lib/combine/parsers/text.ex
@@ -430,7 +430,7 @@ defmodule Combine.Parsers.Text do
       byte_size = :erlang.size(expected)
       case input do
         <<^expected::binary-size(byte_size), rest::binary>> ->
-          new_col = col + byte_size
+          new_col = col + String.length(expected)
           %{state | :column => new_col, :input => rest, :results => [expected|results]}
         _ ->
           %{state | :status => :error, :error => "Expected `#{expected}`, but was not found at line #{line}, column #{col}."}

--- a/test/parsers/text_test.exs
+++ b/test/parsers/text_test.exs
@@ -11,4 +11,17 @@ defmodule Combine.Parsers.Text.Test do
     expected = {:error, "Expected `u`, but found `s` at line 1, column 2."}
     assert ^expected = Combine.parse(input, parser)
   end
+
+  test "string parser updates column index" do
+    input = "ö 1"
+    expected_col = ~r/column 2/
+
+    char_parser = char("ö") |> integer()
+    {:error, msg} = Combine.parse(input, char_parser)
+    assert msg =~ expected_col
+
+    string_parser = string("ö") |> integer()
+    {:error, msg} = Combine.parse(input, string_parser)
+    assert msg =~ expected_col
+  end
 end


### PR DESCRIPTION
Prior to this fix, the column index indicated in error messages would be off for string containing UTF characters.