### PR TITLE
Elixir 1.20

### DIFF
--- a/lib/combine/parsers/binary.ex
+++ b/lib/combine/parsers/binary.ex
@@ -23,7 +23,7 @@ defmodule Combine.Parsers.Binary do
   @spec bits(previous_parser, pos_integer) :: parser
   defparser bits(%ParserState{status: :ok, column: col, input: input, results: results} = state, n) when is_integer(n) do
     case input do
-      <<bits::bitstring-size(n), rest::bitstring>> ->
+      <<bits::bitstring-size(^n), rest::bitstring>> ->
         %{state | :column => col + n, :input => rest, :results => [bits|results]}
       _ ->
         %{state | :status => :error, :error => "Expected #{n} bits starting at position #{col + 1}, but encountered end of input."}
@@ -45,7 +45,7 @@ defmodule Combine.Parsers.Binary do
   defparser bytes(%ParserState{status: :ok, column: col, input: input, results: results} = state, n) when is_integer(n) do
     bits_size = n * 8
     case input do
-      <<bits::bitstring-size(bits_size), rest::bitstring>> ->
+      <<bits::bitstring-size(^bits_size), rest::bitstring>> ->
         %{state | :column => col + bits_size, :input => rest, :results => [bits|results]}
       _ ->
         %{state | :status => :error, :error => "Expected #{n} bytes starting at position #{col + 1}, but encountered end of input."}
@@ -67,14 +67,14 @@ defmodule Combine.Parsers.Binary do
     case endianness do
       :be ->
         case input do
-          <<int::big-unsigned-size(size), rest::bitstring>> ->
+          <<int::big-unsigned-size(^size), rest::bitstring>> ->
             %{state | :column => col + size, :input => rest, :results => [int|results]}
           _ ->
             %{state | :status => :error, :error => "Expected #{size}-bit, unsigned, big-endian integer starting at position #{col + 1}."}
         end
       :le ->
         case input do
-          <<int::little-unsigned-size(size), rest::bitstring>> ->
+          <<int::little-unsigned-size(^size), rest::bitstring>> ->
             %{state | :column => col + size, :input => rest, :results => [int|results]}
           _ ->
             %{state | :status => :error, :error => "Expected #{size}-bit, unsigned, little-endian integer starting at position #{col + 1}."}
@@ -98,14 +98,14 @@ defmodule Combine.Parsers.Binary do
     case endianness do
       :be ->
         case input do
-          <<int::big-signed-size(size), rest::bitstring>> ->
+          <<int::big-signed-size(^size), rest::bitstring>> ->
             %{state | :column => col + size, :input => rest, :results => [int|results]}
           _ ->
             %{state | :status => :error, :error => "Expected #{size}-bit, signed, big-endian integer starting at position #{col + 1}."}
         end
       :le ->
         case input do
-          <<int::little-signed-size(size), rest::bitstring>> ->
+          <<int::little-signed-size(^size), rest::bitstring>> ->
             %{state | :column => col + size, :input => rest, :results => [int|results]}
           _ ->
             %{state | :status => :error, :error => "Expected #{size}-bit, signed, little-endian integer starting at position #{col + 1}."}
@@ -125,7 +125,7 @@ defmodule Combine.Parsers.Binary do
   @spec float(previous_parser, 32 | 64) :: parser
   defparser float(%ParserState{status: :ok, column: col, input: input, results: results} = state, size) when is_integer(size) do
     case input do
-      <<num::float-size(size), rest::bitstring>> ->
+      <<num::float-size(^size), rest::bitstring>> ->
         %{state | :column => col + size, :input => rest, :results => [num|results]}
       _ ->
         %{state | :status => :error, :error => "Expected #{size}-bit, floating point number starting at position #{col + 1}."}

--- a/lib/combine/parsers/text.ex
+++ b/lib/combine/parsers/text.ex
@@ -94,7 +94,7 @@ defmodule Combine.Parsers.Text do
       iex> import #{__MODULE__}
       ...> parser = take_while(fn ?a -> true; _ -> false end)
       ...> Combine.parse("aaaaabbbbb", parser)
-      ['aaaaa']
+      [~c"aaaaa"]
   """
   @spec take_while(previous_parser, (char -> boolean)) :: parser
   defparser take_while(%ParserState{status: :ok} = state, predicate) when is_function(predicate, 1) do

--- a/lib/combine/parsers/text.ex
+++ b/lib/combine/parsers/text.ex
@@ -485,9 +485,6 @@ defmodule Combine.Parsers.Text do
         %{state | :column => col + len, :input => rest, results: [word|results]}
     end
   end
-  defp word_of_impl(%ParserState{status: :ok} = state, _pattern) do
-    %{state | :status => :error, :error => "Expected word, but hit end of input."}
-  end
 
   @doc """
   Parses an integer value from the input.

--- a/lib/combine/parsers/text.ex
+++ b/lib/combine/parsers/text.ex
@@ -429,7 +429,7 @@ defmodule Combine.Parsers.Text do
     when is_binary(expected) do
       byte_size = :erlang.size(expected)
       case input do
-        <<^expected::binary-size(byte_size), rest::binary>> ->
+        <<^expected::binary-size(^byte_size), rest::binary>> ->
           new_col = col + String.length(expected)
           %{state | :column => new_col, :input => rest, :results => [expected|results]}
         _ ->

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -156,7 +156,7 @@ defmodule Combine.Test do
     defstruct method: nil, uri: nil, http_version: nil, headers: []
   end
 
-  @tokens Enum.to_list(32..127) -- '()<>@,;:\\"/[]={} \t'
+  @tokens Enum.to_list(32..127) -- ~c"()<>@,;:\\\"/[]={} \t"
   @digits ?0..?9
   test "RFC-2616" do
     request_parser = sequence([


### PR DESCRIPTION
@bitwalker Fixes a bunch of warnings emitted by elixir on v1.20 with OTP 29.0. You may need to bump the required elixir to ~1.15. Let me know if you have any questions.